### PR TITLE
Format registry change AND requestcopy back to /documents

### DIFF
--- a/src/app/admin/admin-registries/bitstream-formats/format-form/format-form.component.ts
+++ b/src/app/admin/admin-registries/bitstream-formats/format-form/format-form.component.ts
@@ -40,9 +40,10 @@ export class FormatFormComponent implements OnInit {
   /**
    * The different supported support level of the bitstream format
    */
-  supportLevelOptions = [{label: BitstreamFormatSupportLevel.Known, value: BitstreamFormatSupportLevel.Known},
-    {label: BitstreamFormatSupportLevel.Unknown, value: BitstreamFormatSupportLevel.Unknown},
-    {label: BitstreamFormatSupportLevel.Supported, value: BitstreamFormatSupportLevel.Supported}];
+  supportLevelOptions = [{label: BitstreamFormatSupportLevel.AS_IS_UNKNOWN, value: BitstreamFormatSupportLevel.AS_IS_UNKNOWN},
+    {label: BitstreamFormatSupportLevel.LIMITED, value: BitstreamFormatSupportLevel.LIMITED},
+    {label: BitstreamFormatSupportLevel.HIGHEST_LEVEL, value: BitstreamFormatSupportLevel.HIGHEST_LEVEL},
+    {label: BitstreamFormatSupportLevel.AS_IS_KNOWN, value: BitstreamFormatSupportLevel.AS_IS_KNOWN}];
 
   /**
    * Styling element for repeatable field

--- a/src/app/bitstream-page/edit-bitstream-page/edit-bitstream-page.component.ts
+++ b/src/app/bitstream-page/edit-bitstream-page/edit-bitstream-page.component.ts
@@ -536,7 +536,7 @@ export class EditBitstreamPageComponent implements OnInit, OnDestroy {
    */
   isUnknownFormat(id: string): boolean {
     const format = this.formats.find((f: BitstreamFormat) => f.id === id);
-    return hasValue(format) && format.supportLevel === BitstreamFormatSupportLevel.Unknown;
+    return hasValue(format) && format.supportLevel === BitstreamFormatSupportLevel.AS_IS_UNKNOWN;
   }
 
   /**

--- a/src/app/core/shared/bitstream-format-support-level.ts
+++ b/src/app/core/shared/bitstream-format-support-level.ts
@@ -1,5 +1,6 @@
 export enum BitstreamFormatSupportLevel {
-  Known = 'KNOWN',
-  Unknown = 'UNKNOWN',
-  Supported = 'SUPPORTED'
+  AS_IS_UNKNOWN = 'AS_IS_UNKNOWN',
+  LIMITED = 'LIMITED',
+  HIGHEST_LEVEL = 'HIGHEST_LEVEL',
+  AS_IS_KNOWN = 'AS_IS_KNOWN'
 }

--- a/src/app/request-copy/deny-request-copy/deny-request-copy.component.html
+++ b/src/app/request-copy/deny-request-copy/deny-request-copy.component.html
@@ -5,5 +5,6 @@
 
     <ds-themed-email-request-copy [subject]="subject$ | async" [message]="message$ | async" (send)="deny($event)"></ds-themed-email-request-copy>
   </div>
+  dfgdgfsg
   <ds-themed-loading *ngIf="!itemRequestRD || itemRequestRD?.isLoading"></ds-themed-loading>
 </div>

--- a/src/app/request-copy/deny-request-copy/deny-request-copy.component.ts
+++ b/src/app/request-copy/deny-request-copy/deny-request-copy.component.ts
@@ -102,7 +102,7 @@ export class DenyRequestCopyComponent implements OnInit {
     ).subscribe((rd) => {
       if (rd.hasSucceeded) {
         this.notificationsService.success(this.translateService.get('deny-request-copy.success'));
-        this.router.navigateByUrl('/');
+        this.router.navigateByUrl('/documents');
       } else {
         this.notificationsService.error(this.translateService.get('deny-request-copy.error'), rd.errorMessage);
       }

--- a/src/app/request-copy/grant-request-copy/grant-request-copy.component.ts
+++ b/src/app/request-copy/grant-request-copy/grant-request-copy.component.ts
@@ -76,7 +76,7 @@ export class GrantRequestCopyComponent implements OnInit {
     ).subscribe((rd) => {
       if (rd.hasSucceeded) {
         this.notificationsService.success(this.translateService.get('grant-request-copy.success'));
-        this.router.navigateByUrl('/');
+        this.router.navigateByUrl('/documents');
       } else {
         this.notificationsService.error(this.translateService.get('grant-request-copy.error'), rd.errorMessage);
       }

--- a/src/assets/i18n/en.json5
+++ b/src/assets/i18n/en.json5
@@ -132,11 +132,13 @@
 
   "admin.registries.bitstream-formats.table.return": "Back",
 
-  "admin.registries.bitstream-formats.table.supportLevel.KNOWN": "Known",
+  "admin.registries.bitstream-formats.table.supportLevel.AS_IS_UNKNOWN": "Level 3 (As-Is, Unknown)",
 
-  "admin.registries.bitstream-formats.table.supportLevel.SUPPORTED": "Supported",
+  "admin.registries.bitstream-formats.table.supportLevel.LIMITED": "Level 2 (Limited)",
 
-  "admin.registries.bitstream-formats.table.supportLevel.UNKNOWN": "Unknown",
+  "admin.registries.bitstream-formats.table.supportLevel.HIGHEST_LEVEL": "Level 1 (Highest Level)",
+
+  "admin.registries.bitstream-formats.table.supportLevel.AS_IS_KNOWN": "Level 3 (As-Is, Known)",
 
   "admin.registries.bitstream-formats.table.supportLevel.head": "Support Level",
 


### PR DESCRIPTION
(1) Correct Format Registry coding
(2) Send user back to /documents after granting or denying request copy.