### PR TITLE
Clean up

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,91 +1,87 @@
-# AGENTS.md — Coding Agent Guidelines for `show-password-login`
+# AGENTS.md — Coding Agent Guidelines for `mlibrary/dspace-angular`
 
 ## Purpose
 
-This file gives a coding agent everything it needs to continue (or complete) the
-`show-password-login` feature branch in `mlibrary/dspace-angular` without needing
-to ask the human for context.
+This file gives a coding agent everything it needs to work in the
+`mlibrary/dspace-angular` repository without needing to ask the human for context.
+It covers repo orientation, how to find and track work, general coding guidelines,
+and reusable codebase patterns.
 
 ---
 
-## Repository & Branch
+## Repository Overview
 
 | Item | Value |
 |---|---|
 | Repo | `mlibrary/dspace-angular` |
-| Active branch | `show-password-login` |
-| Base branch | `umich` / `issue-working` |
+| Primary branch | `umich` |
 | Framework | Angular 14 / DSpace 7.6 |
 | Language | TypeScript + HTML templates |
+| Fork of | `DSpace/dspace-angular` (upstream) |
+
+This is the University of Michigan customisation of the DSpace Angular frontend.
+UM-specific changes live alongside standard DSpace code; prefer touching only the
+files necessary for each task so merging upstream updates stays manageable.
 
 ---
 
-## The Problem Being Solved
+## Finding and Tracking Work
 
-A UM-specific customisation in `src/app/shared/log-in/log-in.component.html` hard-codes
-the password auth method out of the login UI:
-
-```html
-*ngIf="authMethod.authMethodType !== 'password'"
-```
-
-On the **demo** environment, DSpace OIDC is disabled, making `password` the only advertised
-auth method — leaving a completely blank login form. No one can log in to demo.
-
-Full context: read `PLAN_DSPACE_ANGULAR_PASSWORD_LOGIN.md`.
+1. **Read `TODO.md` first.** It lists all active work items in priority order.
+2. **Read the relevant plan document** in `plans/` before touching any code.
+   Each plan has background, rationale, exact code snippets, and verification steps.
+3. **After completing and committing each task**, mark it done in `TODO.md` and add
+   a summary entry to `DONE.md`.
+4. Plan documents follow the naming convention `plans/PLAN_<FEATURE>.md`.
+   Copy `plans/PLAN_TEMPLATE.md` to start a new plan.
 
 ---
 
-## The Chosen Solution
+## Coding Guidelines
 
-A **config-driven exclusive toggle**: a new `showPasswordLogin` boolean in `AuthConfig`.
+1. **Do not change files outside the scope of the current task** unless fixing a
+   compile/lint error directly caused by your own changes.
 
-- `false` (default) → show OIDC/non-password methods only. Production & workshop unchanged.
-- `true` (demo only) → show password form only, hide OIDC.
+2. **After editing each TypeScript file**, run `get_errors` on that file and fix any
+   issues before moving on.
 
-Template condition (exclusive — never both, never none):
-```html
-*ngIf="showPasswordLogin === (authMethod.authMethodType === 'password')"
-```
+3. **Run affected specs** after updating spec files:
+   ```
+   npx ng test --include='**/path/to/component.spec.ts' \
+     --watch=false --configuration test --browsers=ChromeHeadless
+   ```
 
----
+4. **Commit message convention** — use the Angular commit format:
+   ```
+   <type>: <short summary> (<TICKET-ID>)
+   ```
+   Types: `feat`, `fix`, `test`, `docs`, `refactor`, `chore`.
 
-## Work Tracking Files
+5. **Always pass non-interactive flags to CLI tools** so commands never hang:
+   - `git`: use `git --no-pager <command>` (or pipe through `| cat`) for any command
+     that may open a pager (`log`, `diff`, `show`, `blame`, etc.).
+   - `ng test`: always include `--watch=false --browsers=ChromeHeadless`.
+     Without `--watch=false` the process never exits; without `--browsers=ChromeHeadless`
+     it tries to launch a visible browser window.
+   - Any other interactive tool (`less`, `man`, `top`, etc.): pipe through `| cat` or
+     pass the equivalent "non-interactive / no-pager" flag before running.
 
-| File | Purpose |
-|---|---|
-| `TODO.md` | Remaining tasks in priority order — work from top to bottom |
-| `DONE.md` | Completed tasks — move items here when a task is committed |
-| `PLAN_DSPACE_ANGULAR_PASSWORD_LOGIN.md` | Full design rationale and exact code snippets |
-
-**Always check `TODO.md` first** to see what still needs doing.
-**After completing and committing each task**, move it from `TODO.md` to `DONE.md`.
-
----
-
-## Key Files to Know
-
-| File | Role |
-|---|---|
-| `src/config/auth-config.interfaces.ts` | `AuthConfig` interface — add `showPasswordLogin?: boolean` |
-| `src/config/default-app-config.ts` | `DefaultAppConfig` class — set `showPasswordLogin: false` in `auth` block |
-| `src/app/shared/log-in/log-in.component.ts` | Inject `APP_CONFIG`, read flag, expose as `showPasswordLogin` property |
-| `src/app/shared/log-in/log-in.component.html` | Replace `*ngIf` with exclusive-toggle condition |
-| `src/app/shared/log-in/log-in.component.spec.ts` | Unit test — needs `APP_CONFIG` provided and assertion updated to `toBe(1)` |
-| `src/app/shared/testing/auth-service.stub.ts` | `authMethodsMock` = `[password, shibboleth]` — used by the spec |
-| `src/environments/environment.test.ts` | Full `auth:` block used by specs; does NOT have `showPasswordLogin` (omitting it is fine — `undefined ?? false` → `false`) |
-| `config/config.example.yml` | Operator reference — add commented-out `showPasswordLogin` entry in the `auth:` block |
+6. **Do not modify `config/config.yml`** — that file holds local dev overrides and is
+   not committed. Environment-specific runtime config is injected via environment
+   variables in Kubernetes (see plan documents for details).
 
 ---
 
-## How `APP_CONFIG` Is Used in This Codebase
+## Reusable Codebase Patterns
 
-`APP_CONFIG` is an Angular `InjectionToken<AppConfig>` defined in
-`src/config/app-config.interface.ts`. Inject it into a component constructor like this:
+### `APP_CONFIG` Injection Token
+
+`APP_CONFIG` is an `InjectionToken<AppConfig>` defined in
+`src/config/app-config.interface.ts`. Use it to read runtime config in components:
 
 ```typescript
 import { AppConfig, APP_CONFIG } from '../../../config/app-config.interface';
-// Path from src/app/shared/log-in/ → three levels up → src/config/
+// Adjust the relative path depth to match your component's location.
 
 constructor(
   // ...existing params...
@@ -93,11 +89,7 @@ constructor(
 ) {}
 ```
 
-Existing examples to reference:
-- `src/app/community-list-page/community-list-service.ts`
-- `src/app/item-page/edit-item-page/virtual-metadata/virtual-metadata.component.ts`
-
-In test files, provide it as:
+Provide it in tests with:
 ```typescript
 import { APP_CONFIG } from '../../../config/app-config.interface';
 import { environment } from '../../../environments/environment';
@@ -105,82 +97,53 @@ import { environment } from '../../../environments/environment';
 { provide: APP_CONFIG, useValue: environment }
 ```
 
-`environment` (resolves to `environment.test.ts` during tests) has a full `auth:` block
-but no `showPasswordLogin` key. That is fine — the component reads it as
-`appConfig.auth?.showPasswordLogin ?? false`, so `undefined ?? false` → `false`.
-No change to `environment.test.ts` is required.
+Existing injection examples to reference:
+- `src/app/community-list-page/community-list-service.ts`
+- `src/app/item-page/edit-item-page/virtual-metadata/virtual-metadata.component.ts`
+
+### Adding a New Config Flag
+
+1. Add `myFlag?: boolean` to the relevant interface in `src/config/`.
+2. Set the default value in `src/config/default-app-config.ts`.
+3. Document it as a commented-out entry in `config/config.example.yml`.
+4. Read it in the component via `this.appConfig.section?.myFlag ?? defaultValue`.
+
+The config system merges `DSPACE_*` environment variables at startup —
+`DSPACE_AUTH_MYFLAG=true` maps to `auth.myFlag`. The env-var override works even
+when the default is `false` because `isNotEmpty(false) === true`.
+
+### Angular Testing with `CUSTOM_ELEMENTS_SCHEMA`
+
+Many specs declare `CUSTOM_ELEMENTS_SCHEMA` to avoid registering every child component.
+Key consequences:
+
+- `By.css('ds-some-component')` returns elements, but `componentInstance` and
+  `properties['input']` are **not** available — Angular never instantiates the class.
+- `By.directive(SomeComponent)` **does** work when `SomeComponent` is declared (e.g.
+  via `SharedModule`) — it finds real instantiated component objects.
+- To inspect which auth method rendered in `LogInComponent`, query for the inner method
+  component that `ngComponentOutlet` created:
+  ```typescript
+  By.directive(LogInPasswordComponent)           // password path
+  By.directive(LogInExternalProviderComponent)   // OIDC/shibboleth path
+  ```
+
+### `TestBed.overrideProvider()` Limitation
+
+`TestBed.overrideProvider()` throws *"Cannot override provider when the test module has
+already been instantiated"* when called inside an `it()` or `beforeEach()` that runs
+after `TestBed.createComponent()`. Calling `fixture.destroy()` first does **not** reset
+module state.
+
+Alternatives:
+- Set the component property directly: `component.myFlag = true; fixture.detectChanges()`.
+- Put `overrideProvider()` inside `beforeEach()` **before** `compileComponents()`, in a
+  nested `describe` block that has its own `TestBed.configureTestingModule` call.
 
 ---
 
-## Spec File Notes
+## Plans Index
 
-`src/app/shared/log-in/log-in.component.spec.ts` currently has:
-
-```typescript
-it('should render a log-in container component for each auth method available', () => {
-  const loginContainers = fixture.debugElement.queryAll(By.css('ds-log-in-container'));
-  expect(loginContainers.length).toBe(2);  // ← must change to toBe(1)
-});
-```
-
-`authMethodsMock` contains `[password, shibboleth]`. With `showPasswordLogin: false` (default),
-only `shibboleth` renders → `toBe(1)`. The `APP_CONFIG` token must also be added to
-`providers` in `TestBed.configureTestingModule` or the component will fail to construct.
-
----
-
-## `config/config.example.yml` — Operator Documentation
-
-The `auth:` block in `config/config.example.yml` (around line 91–102) must have a
-commented-out `showPasswordLogin` entry added so operators know the option exists:
-
-```yaml
-# When true, show the username/password login form and hide OIDC (exclusive toggle).
-# Set to true only on environments where DSpace OIDC is disabled (e.g. demo).
-# Default: false (OIDC button shown, password form hidden — production/workshop behaviour).
-# Can also be set via environment variable: DSPACE_AUTH_SHOWPASSWORDLOGIN=true
-# showPasswordLogin: false
-```
-
----
-
-## Config Override for Demo (Out-of-Band)
-
-The demo Kubernetes frontend Deployment/ConfigMap (in `mlibrary/deepblue-documents-kube`,
-**not** this repo) must set:
-
-```
-DSPACE_AUTH_SHOWPASSWORDLOGIN=true
-```
-
-This task is tracked in `TODO.md` item 9. It is performed separately from this repo's code changes.
-
----
-
-## Coding Guidelines
-
-1. **Read `TODO.md` first.** Work tasks in the listed order (they have dependencies).
-2. **After completing and committing each task**, update `TODO.md` (mark done / remove) and
-   add the task to `DONE.md`.
-3. **Do not change any file not listed in `TODO.md`** unless fixing a compile/lint error
-   directly caused by your changes.
-4. **After editing each TypeScript file**, run `get_errors` on that file and fix any issues
-   before moving on.
-5. **Run the spec** after updating the spec file:
-   `npx ng test --include='**/log-in/log-in.component.spec.ts' --watch=false --configuration test --browsers=ChromeHeadless`
-6. **Commit message convention:**
-   `feat: config-driven showPasswordLogin exclusive toggle (DEEPBLUE-466)`
-7. The `config/config.yml` in this repo is **not** the demo config — do not modify it.
-   The demo override happens via environment variable in the Kubernetes repo.
-8. Do not remove the `<!--` comment block in `log-in.component.html` (lines 11–15) —
-   it is intentionally left commented out.
-9. **Always pass non-interactive flags to CLI tools** so commands never hang waiting for
-   user input. Key flags for this repo:
-   - `git`: use `git --no-pager <command>` (or pipe through `| cat`) for any command that
-     may open a pager (`log`, `diff`, `show`, `blame`, etc.).
-   - `ng test`: always include `--watch=false --browsers=ChromeHeadless` — without
-     `--watch=false` the process never exits; without `--browsers=ChromeHeadless` it
-     tries to launch a visible browser window.
-   - Any other interactive tool (`less`, `man`, `top`, etc.): pipe through `| cat` or
-     pass the equivalent "non-interactive / no-pager" flag before running.
-
+| Plan file | Feature | Status |
+|---|---|---|
+| `plans/PLAN_DSPACE_ANGULAR_PASSWORD_LOGIN.md` | Config-driven `showPasswordLogin` toggle | ✅ Merged (PR #94) |

--- a/DONE.md
+++ b/DONE.md
@@ -1,125 +1,56 @@
-# DONE — show-password-login implementation
+# DONE — mlibrary/dspace-angular
 
-Tasks completed and committed to the `show-password-login` branch.
-
----
-
-## ✅ Branch created
-
-- Branch `show-password-login` cut from `umich` / `issue-working`.
+Completed work items, grouped by feature. Each group links to its plan document and
+the PR that merged it.
 
 ---
 
-## ✅ Plan document written and committed
+## ✅ Config-driven `showPasswordLogin` toggle (DEEPBLUE-466)
 
-- **Commit:** `90a6627c3` — "Initial Plan"
-- **File:** `PLAN_DSPACE_ANGULAR_PASSWORD_LOGIN.md`
-- Describes the problem, the config-driven exclusive-toggle approach, all four source-file
-  changes, the demo-only config override, a truth table, and verification steps.
+**Plan:** `plans/PLAN_DSPACE_ANGULAR_PASSWORD_LOGIN.md`
+**Branch:** `show-password-login` → merged to `umich` as **PR #94**
 
----
+### What was done
 
-## ✅ Tracking files created and committed
+**Source changes** (commit `54c6b93c4` — `feat: config-driven showPasswordLogin exclusive toggle`):
 
-- **Commit:** `7485e2d6c` — "docs: add TODO, DONE, and AGENTS tracking files for showPasswordLogin feature"
-- **Files:** `TODO.md`, `DONE.md`, `AGENTS.md`
+- `src/config/auth-config.interfaces.ts` — added `showPasswordLogin?: boolean` to `AuthConfig`.
+- `src/config/default-app-config.ts` — added `showPasswordLogin: false` to the `auth` block.
+- `src/app/shared/log-in/log-in.component.ts` — injected `APP_CONFIG`; set
+  `this.showPasswordLogin = this.appConfig.auth?.showPasswordLogin ?? false` in `ngOnInit()`.
+- `src/app/shared/log-in/log-in.component.html` — replaced hard-coded
+  `*ngIf="authMethod.authMethodType !== 'password'"` with the exclusive toggle
+  `*ngIf="showPasswordLogin === (authMethod.authMethodType === 'password')"`.
+- `config/config.example.yml` — added commented-out `showPasswordLogin` entry with docs.
 
----
+**Pre-existing spec fixes** (commit `531f1e703`):
+14 TypeScript errors across 9 spec files on the base branch were blocking `ng test`.
+Fixed: missing `serverLocation` in `environment.test.ts`, wrong `setWithDrawn` arity,
+and stale bitstream-format enum names (`Unknown`/`Known`/`Supported` →
+`AS_IS_UNKNOWN`/`AS_IS_KNOWN`/`HIGHEST_LEVEL`).
 
-## ✅ Tasks 1–6: source changes implemented and committed
+**Spec strengthened** (commits `838275570`, `d46949e32`, `3c57ff73f`):
+- Added `APP_CONFIG` provider to `TestBed`.
+- Updated container count assertion from `toBe(2)` → `toBe(1)`.
+- Added test for `showPasswordLogin: true` using direct property mutation +
+  `By.directive(LogInPasswordComponent)` / `By.directive(LogInExternalProviderComponent)`
+  to prove which method renders, not just the count.
+- Renamed `it()` descriptions to reflect exclusive-toggle semantics.
 
-- **Commit:** `54c6b93c4` — "feat: config-driven showPasswordLogin exclusive toggle (DEEPBLUE-466)"
-
-### Task 1 — `src/config/auth-config.interfaces.ts`
-Added `showPasswordLogin?: boolean` to the `AuthConfig` interface with JSDoc comment.
-
-### Task 2 — `src/config/default-app-config.ts`
-Added `showPasswordLogin: false` to the `auth` block in `DefaultAppConfig`.
-
-### Task 3 — `src/app/shared/log-in/log-in.component.ts`
-- Added `Inject` to `@angular/core` import.
-- Added `import { AppConfig, APP_CONFIG } from '../../../config/app-config.interface'`.
-- Declared `public showPasswordLogin: boolean` property.
-- Added `@Inject(APP_CONFIG) private appConfig: AppConfig` as last constructor parameter.
-- Set `this.showPasswordLogin = this.appConfig.auth?.showPasswordLogin ?? false` at top of `ngOnInit()`.
-
-### Task 4 — `src/app/shared/log-in/log-in.component.html`
-Changed `*ngIf` from:
-```html
-*ngIf="authMethod.authMethodType !== 'password'"
-```
-to the exclusive toggle:
-```html
-*ngIf="showPasswordLogin === (authMethod.authMethodType === 'password')"
-```
-
-### Task 5 — `src/app/shared/log-in/log-in.component.spec.ts`
-- Added `APP_CONFIG` and `environment` imports.
-- Added `{ provide: APP_CONFIG, useValue: environment }` to `TestBed` providers.
-- Updated assertion from `toBe(2)` to `toBe(1)` (only shibboleth renders with `showPasswordLogin: false`).
-
-### Task 6 — `config/config.example.yml`
-Added commented-out `showPasswordLogin` entry with documentation in the `auth:` block.
+### Pending (out-of-band)
+- Set `DSPACE_AUTH_SHOWPASSWORDLOGIN=true` in the demo Kubernetes ConfigMap
+  (`mlibrary/deepblue-documents-kube`). Tracked in `TODO.md` Task 9.
 
 ---
 
-## ✅ Task 7: Unit test confirmed passing
+## ✅ Task A — Generalize coding-agent markdown files
 
-- **Commit:** `531f1e703` — "fix: resolve pre-existing TypeScript errors in base-branch spec files to unblock test run"
+**Branch:** `clean-up` → merged to `umich` as **PR #___**
 
-The `umich` base branch had 14 pre-existing TypeScript errors across 9 spec files that
-prevented `ng test` from starting. These were fixed to unblock test verification:
-
-- `src/environments/environment.test.ts` — added missing `serverLocation: 'http://localhost:8080/server'`
-- `src/app/item-page/edit-item-page/item-withdraw/item-withdraw.component.spec.ts` — added missing `reason` arg to `setWithDrawn` assertion
-- `src/app/item-page/edit-item-page/item-reinstate/item-reinstate.component.spec.ts` — same
-- 6 bitstream-format spec files — renamed old enum values to current names:
-  - `Unknown` → `AS_IS_UNKNOWN`
-  - `Known` → `AS_IS_KNOWN`
-  - `Supported` → `HIGHEST_LEVEL`
-
-**Test result:** ✅ 2 specs, 0 failures
-```
-✔ should render a log-in container component for each auth method available
-✔ should create LogInComponent
-TOTAL: 2 SUCCESS
-```
-
----
-
-## ✅ Task 8: Spec strengthened — assertions prove which auth method renders
-
-Reviewing-agent feedback requested stronger assertions that prove the exclusive toggle
-switches **which** auth method is shown, not just that count === 1.
-
-### Approach
-`LogInContainerComponent` uses `ngComponentOutlet` to dynamically render the inner
-method component. The inner component type uniquely identifies which auth method rendered:
-- `shibboleth` → renders `LogInExternalProviderComponent`
-- `password`   → renders `LogInPasswordComponent`
-
-`By.directive(InnerComponent)` finds real Angular instances regardless of
-`CUSTOM_ELEMENTS_SCHEMA`, so it reliably identifies which method was rendered.
-
-### Changes made
-- **Test 1** (`showPasswordLogin: false` / default): added
-  `expect(loginContainers[0].componentInstance.authMethod.authMethodType).toBe('shibboleth')`,
-  `By.directive(LogInExternalProviderComponent).length === 1`, and
-  `By.directive(LogInPasswordComponent).length === 0`.
-- **Test 2** (new — `showPasswordLogin: true`): sets `component.showPasswordLogin = true`,
-  double `detectChanges()`, asserts container count === 1,
-  `By.directive(LogInPasswordComponent).length === 1`, and
-  `By.directive(LogInExternalProviderComponent).length === 0`.
-- **Removed** a duplicate/broken third `it` block that used
-  `By.css('ds-log-in-container')[0].properties['authMethod']` — Angular does not
-  serialize object bindings to DOM properties under `CUSTOM_ELEMENTS_SCHEMA`,
-  so `properties['authMethod']` was always `undefined`.
-
-**Test result:** ✅ 3 specs, 0 failures
-```
-✔ should create LogInComponent
-✔ should render a log-in container component for each auth method available
-✔ should render only the password auth method when showPasswordLogin is enabled
-TOTAL: 3 SUCCESS
-```
-
+- Moved `PLAN_DSPACE_ANGULAR_PASSWORD_LOGIN.md` → `plans/`.
+- Rewrote `AGENTS.md` as repo-wide guidance (removed feature-specific content;
+  added repo overview, general coding guidelines, reusable codebase patterns,
+  plans index).
+- Rewrote `TODO.md` to support multiple parallel work items.
+- Rewrote `DONE.md` (this file) as a general feature archive.
+- Added `plans/PLAN_TEMPLATE.md` for future features.

--- a/PULL_REQUEST.md
+++ b/PULL_REQUEST.md
@@ -1,108 +1,54 @@
-# DEEPBLUE-466 — Config-driven password login toggle for demo environment
+# clean-up — Generalize coding-agent markdown files
 
 ## Summary
 
-Restores the password login form on the **demo** environment without changing
-production or workshop behaviour.
+Converts the `show-password-login`-specific agent-guidance files into
+repo-wide, feature-agnostic tooling that can support multiple plans and
+work items running in parallel.
 
-A new `showPasswordLogin` config flag (default `false`) acts as an **exclusive toggle**:
-
-| `showPasswordLogin` | Login UI | Environment |
-|---|---|---|
-| `false` (default) | OIDC button only | production, workshop — **no change** |
-| `true` | Password form only | demo |
-
----
-
-## Background
-
-Deep Blue Documents has three Kubernetes environments: production, workshop, and demo.
-
-**Demo** uses a two-layer auth model:
-1. `oauth2-proxy` gate requires U-M WebLogin (Shibboleth OIDC) — restricts access to U-M people.
-2. Inside the gate, users log in to DSpace with **username/password** to switch test personas.
-
-DSpace's internal OIDC is intentionally disabled for demo so testers aren't auto-logged-in
-as their own umich.edu identity. An existing UM customisation (`*ngIf="authMethod.authMethodType !== 'password'"`) removed the password form from the UI — which was fine when OIDC was the
-active method but leaves a completely **blank login page** now that OIDC is disabled.
+No source code is changed. All commits are documentation only.
 
 ---
 
 ## Changes
 
-### `src/config/auth-config.interfaces.ts`
-Added `showPasswordLogin?: boolean` to `AuthConfig`.
+### `PLAN_DSPACE_ANGULAR_PASSWORD_LOGIN.md` → `plans/PLAN_DSPACE_ANGULAR_PASSWORD_LOGIN.md`
+Moved the plan document into a new `plans/` directory so all per-feature
+design documents live in one place. Updated the file's own header to reflect
+its new path and merged status.
 
-### `src/config/default-app-config.ts`
-Defaulted `showPasswordLogin: false` — all environments preserve current behaviour
-unless they explicitly opt in.
+### `plans/PLAN_TEMPLATE.md` *(new)*
+Blank plan template for future features. Sections: Problem, Chosen Solution,
+Key Files, Exact Code Changes, Config / Environment Variables, Truth Table,
+Verification Steps, Out-of-Band Tasks.
 
-### `src/app/shared/log-in/log-in.component.ts`
-Injected `APP_CONFIG`; reads flag into `public showPasswordLogin: boolean`.
+### `AGENTS.md`
+Rewritten as repo-wide coding-agent guidelines. Removed all
+`show-password-login`-specific content. Now contains:
+- Repository overview (framework, language, conventions).
+- How to find work (`TODO.md` → `plans/` document).
+- Six general coding guidelines (non-interactive CLI flags, `get_errors`
+  after every TS edit, commit message convention, `ng test` flags, etc.).
+- Reusable codebase patterns: `APP_CONFIG` injection, adding a config flag,
+  `CUSTOM_ELEMENTS_SCHEMA` behaviour, `TestBed.overrideProvider()` limitation.
+- Plans index table (one row per feature).
 
-### `src/app/shared/log-in/log-in.component.html`
-Replaced:
-```html
-*ngIf="authMethod.authMethodType !== 'password'"
-```
-with the exclusive toggle:
-```html
-*ngIf="showPasswordLogin === (authMethod.authMethodType === 'password')"
-```
+### `TODO.md`
+Rewritten to support multiple parallel work items. Each work item is a
+top-level heading with its own subtask checklist and a reference to the
+relevant plan document.
 
-### `src/app/shared/log-in/log-in.component.spec.ts`
-Provided `APP_CONFIG` token in `TestBed`; updated `toBe(2)` → `toBe(1)`.
-
-### `config/config.example.yml`
-Documented the new flag (commented out) in the `auth:` block for operators.
-
----
-
-## Configuration
-
-Enable for demo via frontend Kubernetes ConfigMap environment variable:
-```
-DSPACE_AUTH_SHOWPASSWORDLOGIN=true
-```
-
-The DSpace Angular config system translates this to a proper boolean `true`
-via `getBooleanFromString` (verified). Production and workshop must NOT set
-this variable — omitting it is sufficient.
-
-> ⚠️ **This PR does not touch the Kubernetes config.** Setting the env-var
-> in `mlibrary/deepblue-documents-kube` is a separate follow-up step.
+### `DONE.md`
+Rewritten as a general feature archive. Each completed feature is a
+top-level heading with its plan reference, branch, PR number, and a
+concise summary of what was done.
 
 ---
 
-## Also fixed in this PR
+## Why
 
-The `umich` base branch had 14 TypeScript compilation errors in 9 spec files
-that prevented the test suite from starting at all. Fixed as part of this PR:
-
-- `environment.test.ts` — missing `serverLocation` property required by `BuildConfig`
-- `item-withdraw.component.spec.ts` / `item-reinstate.component.spec.ts` — `setWithDrawn` now requires a `reason` argument (TS2554)
-- 6 bitstream-format spec files — `BitstreamFormatSupportLevel` enum values renamed: `Unknown → AS_IS_UNKNOWN`, `Known → AS_IS_KNOWN`, `Supported → HIGHEST_LEVEL`
-
----
-
-## Testing
-
-- ✅ Unit tests: `log-in.component.spec.ts` — 2 specs, 0 failures
-- ✅ Config flow verified end-to-end: env-var → `buildAppConfig` → `extendEnvironmentWithAppConfig` → `APP_CONFIG` token → component → template
-- ✅ `isNotEmpty(false) === true` confirmed — the env-var is **not** silently ignored when the default value is `false`
-
-See `PLAN_DSPACE_ANGULAR_PASSWORD_LOGIN.md` for full rationale, config system
-deep-dive, on-host debugging commands, and post-deployment verification steps.
-
----
-
-## Verification after demo deployment
-
-1. Navigate to `https://demo.deepblue-documents.lib.umich.edu` — gate challenges for U-M WebLogin.
-2. After passing the gate, click **Log In**.
-3. A username/password form appears (no OIDC button). ✅
-4. Log in as `dbrrds@umich.edu`. Confirm login succeeds. ✅
-5. Log out; log in as the alternate demo persona (for example `tildon@umich.edu`) using credentials retrieved from the approved secret manager / restricted ops runbook referenced in `PLAN_DSPACE_ANGULAR_PASSWORD_LOGIN.md` — confirm persona switching works. ✅
-
-For **production/workshop**: login still shows only the OIDC button. No regression. ✅
-
+The previous files were written during the `show-password-login` sprint and
+were tightly coupled to that feature. As the next feature work starts, a
+coding agent that reads `AGENTS.md` / `TODO.md` would be confused by
+feature-specific instructions. This PR makes the system self-consistent and
+ready for the next task.

--- a/TODO.md
+++ b/TODO.md
@@ -42,7 +42,7 @@ in parallel, and move plan documents into a dedicated `plans/` directory.
       agent can copy when starting a new feature, with sections for: Problem, Chosen
       Solution, Key Files, Truth Table / Example Config, Verification Steps.
 
-- [ ] **A6. Commit all changes** on `clean-up` and open a PR against `umich`.
+- [x] **A6. Commit all changes** on `clean-up` and open a PR against `umich`.
 
 ---
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,11 +1,52 @@
-# TODO — show-password-login implementation
+# TODO — mlibrary/dspace-angular
 
-Tasks are listed in dependency order. Complete them top-to-bottom.
-Move each task to `DONE.md` when it is committed to the `show-password-login` branch.
+Tasks are listed in dependency order within each work item.
+Complete subtasks top-to-bottom, then move the finished task to `DONE.md`.
+
+Multiple work items may be in progress in parallel; each is tracked under its own heading.
 
 ---
 
-## 9. Note in Kubernetes repo (out-of-band — different repository)
+## Task A — Generalize coding-agent markdown files
+
+**Branch:** `clean-up`
+**Goal:** Replace the `show-password-login`-specific agent files (`AGENTS.md`, `TODO.md`,
+`DONE.md`) with general-purpose equivalents that can track multiple plans and work items
+in parallel, and move plan documents into a dedicated `plans/` directory.
+
+### Subtasks (in order)
+
+- [ ] **A1. Create `plans/` directory** — move `PLAN_DSPACE_ANGULAR_PASSWORD_LOGIN.md`
+      into `plans/` so all per-feature design documents live in one place.
+      Update any cross-references inside the file to reflect its new path.
+
+- [ ] **A2. Rewrite `AGENTS.md`** — strip out all `show-password-login`-specific content
+      and replace with repo-wide guidance:
+      - Repository overview (framework, language, conventions).
+      - How to find work: read `TODO.md`, read the relevant `plans/` document.
+      - General coding guidelines (currently guideline 9 about non-interactive CLI flags —
+        keep and expand as the canonical list for all agents).
+      - Reusable codebase patterns worth knowing (e.g. `APP_CONFIG` injection, Angular
+        testing patterns, `By.directive` vs `CUSTOM_ELEMENTS_SCHEMA`).
+      - Remove all references to a specific branch, ticket, or feature.
+
+- [ ] **A3. Rewrite `TODO.md`** (this file) — convert to the general format illustrated
+      here: tasks grouped by work item, each referencing its plan document, no hardcoded
+      branch or feature names in the file header.
+
+- [ ] **A4. Rewrite `DONE.md`** — convert to a general archive grouped by work item /
+      feature, each group headed by the feature name and merged-PR reference rather than
+      a flat chronological list tied to `show-password-login`.
+
+- [ ] **A5. Add a `plans/PLAN_TEMPLATE.md`** — a blank plan template that a human or
+      agent can copy when starting a new feature, with sections for: Problem, Chosen
+      Solution, Key Files, Truth Table / Example Config, Verification Steps.
+
+- [ ] **A6. Commit all changes** on `clean-up` and open a PR against `umich`.
+
+---
+
+## Task 9 — Kubernetes demo config (out-of-band — different repository)
 
 This task is tracked here for completeness; it is performed in `mlibrary/deepblue-documents-kube`,
 not in this repo.

--- a/TODO.md
+++ b/TODO.md
@@ -16,11 +16,11 @@ in parallel, and move plan documents into a dedicated `plans/` directory.
 
 ### Subtasks (in order)
 
-- [ ] **A1. Create `plans/` directory** — move `PLAN_DSPACE_ANGULAR_PASSWORD_LOGIN.md`
+- [x] **A1. Create `plans/` directory** — move `PLAN_DSPACE_ANGULAR_PASSWORD_LOGIN.md`
       into `plans/` so all per-feature design documents live in one place.
       Update any cross-references inside the file to reflect its new path.
 
-- [ ] **A2. Rewrite `AGENTS.md`** — strip out all `show-password-login`-specific content
+- [x] **A2. Rewrite `AGENTS.md`** — strip out all `show-password-login`-specific content
       and replace with repo-wide guidance:
       - Repository overview (framework, language, conventions).
       - How to find work: read `TODO.md`, read the relevant `plans/` document.
@@ -30,15 +30,15 @@ in parallel, and move plan documents into a dedicated `plans/` directory.
         testing patterns, `By.directive` vs `CUSTOM_ELEMENTS_SCHEMA`).
       - Remove all references to a specific branch, ticket, or feature.
 
-- [ ] **A3. Rewrite `TODO.md`** (this file) — convert to the general format illustrated
+- [x] **A3. Rewrite `TODO.md`** (this file) — convert to the general format illustrated
       here: tasks grouped by work item, each referencing its plan document, no hardcoded
       branch or feature names in the file header.
 
-- [ ] **A4. Rewrite `DONE.md`** — convert to a general archive grouped by work item /
+- [x] **A4. Rewrite `DONE.md`** — convert to a general archive grouped by work item /
       feature, each group headed by the feature name and merged-PR reference rather than
       a flat chronological list tied to `show-password-login`.
 
-- [ ] **A5. Add a `plans/PLAN_TEMPLATE.md`** — a blank plan template that a human or
+- [x] **A5. Add a `plans/PLAN_TEMPLATE.md`** — a blank plan template that a human or
       agent can copy when starting a new feature, with sections for: Problem, Chosen
       Solution, Key Files, Truth Table / Example Config, Verification Steps.
 

--- a/plans/PLAN_DSPACE_ANGULAR_PASSWORD_LOGIN.md
+++ b/plans/PLAN_DSPACE_ANGULAR_PASSWORD_LOGIN.md
@@ -1,7 +1,8 @@
 # Plan: Restore Password Login Form in DSpace Angular (Config-Driven Toggle)
 
 **Repository:** `mlibrary/dspace-angular`
-**Branch:** `show-password-login`
+**Plan file:** `plans/PLAN_DSPACE_ANGULAR_PASSWORD_LOGIN.md`
+**Branch:** `show-password-login` (merged → `umich`)
 **Status:** ✅ Code complete — unit tests passing — pending demo Kubernetes config (Task 9)
 **Approach:** Config-driven `showPasswordLogin` flag so production/workshop behaviour is unchanged
 

--- a/plans/PLAN_TEMPLATE.md
+++ b/plans/PLAN_TEMPLATE.md
@@ -1,0 +1,83 @@
+# Plan: <Feature Name>
+
+**Repository:** `mlibrary/dspace-angular`
+**Plan file:** `plans/PLAN_<FEATURE>.md`
+**Branch:** `<branch-name>`
+**Ticket:** `<TICKET-ID>`
+**Status:** 🚧 In progress
+
+---
+
+## Problem
+
+<!-- What is broken or missing? What environment is affected? -->
+
+---
+
+## Chosen Solution
+
+<!-- Describe the approach chosen and why. If alternatives were considered, list them here. -->
+
+---
+
+## Key Files
+
+| File | Change needed |
+|---|---|
+| `path/to/file.ts` | Description of change |
+
+---
+
+## Exact Code Changes
+
+<!-- Paste the before/after snippets for each file so an agent can implement without guessing. -->
+
+### `path/to/file.ts`
+
+**Before:**
+```typescript
+// existing code
+```
+
+**After:**
+```typescript
+// new code
+```
+
+---
+
+## Config / Environment Variables
+
+<!-- If the feature is config-driven, document the flag name, default, and env-var override. -->
+
+| Flag | Default | Env-var override | Notes |
+|---|---|---|---|
+| `section.flagName` | `false` | `DSPACE_SECTION_FLAGNAME=true` | Description |
+
+---
+
+## Truth Table
+
+<!-- Optional: for boolean toggles, show all combinations and expected outcomes. -->
+
+| Flag value | Behaviour |
+|---|---|
+| `false` (default) | … |
+| `true` | … |
+
+---
+
+## Verification Steps
+
+1. Build and start the app locally.
+2. …
+3. Confirm expected behaviour.
+
+---
+
+## Out-of-Band Tasks
+
+<!-- Tasks in other repositories or infrastructure that must accompany this change. -->
+
+- [ ] Set `ENV_VAR=value` in Kubernetes ConfigMap for `<environment>` (`mlibrary/deepblue-documents-kube`).
+


### PR DESCRIPTION
# clean-up — Generalize coding-agent markdown files

## Summary

Converts the `show-password-login`-specific agent-guidance files into
repo-wide, feature-agnostic tooling that can support multiple plans and
work items running in parallel.

No source code is changed. All commits are documentation only.

---

## Changes

### `PLAN_DSPACE_ANGULAR_PASSWORD_LOGIN.md` → `plans/PLAN_DSPACE_ANGULAR_PASSWORD_LOGIN.md`
Moved the plan document into a new `plans/` directory so all per-feature
design documents live in one place. Updated the file's own header to reflect
its new path and merged status.

### `plans/PLAN_TEMPLATE.md` *(new)*
Blank plan template for future features. Sections: Problem, Chosen Solution,
Key Files, Exact Code Changes, Config / Environment Variables, Truth Table,
Verification Steps, Out-of-Band Tasks.

### `AGENTS.md`
Rewritten as repo-wide coding-agent guidelines. Removed all
`show-password-login`-specific content. Now contains:
- Repository overview (framework, language, conventions).
- How to find work (`TODO.md` → `plans/` document).
- Six general coding guidelines (non-interactive CLI flags, `get_errors`
  after every TS edit, commit message convention, `ng test` flags, etc.).
- Reusable codebase patterns: `APP_CONFIG` injection, adding a config flag,
  `CUSTOM_ELEMENTS_SCHEMA` behaviour, `TestBed.overrideProvider()` limitation.
- Plans index table (one row per feature).

### `TODO.md`
Rewritten to support multiple parallel work items. Each work item is a
top-level heading with its own subtask checklist and a reference to the
relevant plan document.

### `DONE.md`
Rewritten as a general feature archive. Each completed feature is a
top-level heading with its plan reference, branch, PR number, and a
concise summary of what was done.

---

## Why

The previous files were written during the `show-password-login` sprint and
were tightly coupled to that feature. As the next feature work starts, a
coding agent that reads `AGENTS.md` / `TODO.md` would be confused by
feature-specific instructions. This PR makes the system self-consistent and
ready for the next task.
